### PR TITLE
Sorting the blog post using the arel table

### DIFF
--- a/app/models/blog_post.rb
+++ b/app/models/blog_post.rb
@@ -2,7 +2,8 @@ class BlogPost < ApplicationRecord
   validates :title, presence: true
   validates :body, presence: true
 
-  scope :sorted, -> {order(published_at: :desc, updated_at: :desc)}
+  # scope :sorted, -> {order(Arel.sql("published_at desc nulls last"), updated_at: :desc)}
+  scope :sorted, -> {order(arel_table[:published_at].desc.nulls_last, updated_at: :desc)}
   scope :draft, -> {where(published_at: nil)}
   scope :published, -> {where('published_at <= ?', Time.current)}
   scope :scheduled, -> {where('published_at > ?', Time.current)}


### PR DESCRIPTION
If we need to write the raw query, we can use the:
```
Arel.sql("published_at desc nulls last")
```

or

```
arel_table[:published_at].desc.nulls.last
```